### PR TITLE
Fix formatting of code blocks

### DIFF
--- a/html/frontend.js
+++ b/html/frontend.js
@@ -205,7 +205,10 @@ var snippet = (function () {
 			languageLink = document.getElementById("lang").href,
 			code = document.getElementById("code").value,
 			codeLength = (custom[language] ? code : unescape(encodeURIComponent(code))).length;
-		return "# [" + language + "](" + languageLink + "), " + codeLength + " byte" + (codeLength == 1 ? "" : "s") + "\n[Try it online!](" + window.location.href + ")\n\n" + code.replace(/^/g, '		');
+
+		return "# [" + language + "](" + languageLink + "), " +
+			codeLength + " byte" + (codeLength == 1 ? "" : "s") +
+			"\n[Try it online!](" + window.location.href + ")\n\n" + code.replace(/^/gm, '    ');
 	}
 })();
 


### PR DESCRIPTION
I added the `m` flag to the regex to add spaces to the beginning of each line, not just the first, and somewhere the four spaces were changed into two tabs.